### PR TITLE
Add async API

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ tokio = ["hepmc2-macros/tokio", "dep:tokio"]
 criterion = "0.5.1"
 rand = "0.8.4"
 rand_xoshiro = "0.6.0"
-tokio = { version = "1.35.1", features = ["rt", "macros"] }
+tokio = { version = "1.35.1", features = ["rt", "macros", "fs"] }
+tokio-test = "0.4.3"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["physics", "parser"]
 categories = ["science", "parser-implementations"]
 repository = "https://github.com/a-maier/hepmc2"
 
+[workspace]
+members = ["hepmc2-macros"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
@@ -17,11 +20,23 @@ nom = "7"
 ryu = "1.0"
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1.0"
+hepmc2-macros = { version = "0.1.0", path = "hepmc2-macros" }
+tokio = { version = "1.35", features = [
+    "io-util",
+    "rt-multi-thread",
+], optional = true }
+maybe-async = "0.2"
+
+[features]
+default = ["sync"]
+sync = ["hepmc2-macros/sync", "maybe-async/is_sync"]
+tokio = ["hepmc2-macros/tokio", "dep:tokio"]
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.4"
 rand_xoshiro = "0.6.0"
+tokio = { version = "1.35.1", features = ["rt", "macros"] }
 
 [[bench]]
 name = "benchmark"

--- a/Readme.md
+++ b/Readme.md
@@ -33,4 +33,48 @@ for event in in_events {
 writer.finish()?;
 ```
 
+## Async API
+
+By default this crate enables the `sync` feature which exposes a sync API. You
+can however switch to using a `tokio`-backed async API by disabling the `sync`
+feature and enabling the `tokio` feature.
+
+Either run the following in the root of your crate:
+
+```sh
+cargo add hepmc2 --no-default-features -F tokio
+```
+
+or make sure a line like the following is present in your `Cargo.toml`:
+
+```toml
+hepmc2 = { version = "0.6.0", default-features = false, features = ["tokio"] }
+```
+
+The async API is exactly the same as the sync one but IO operations will return
+futures that you will, as usual, need to call `await` on.
+
+### Example
+
+```rust
+// Read events from `events_in.hepmc2` and write them to `events_out.hepmc2`
+use hepmc2::{Reader, Writer};
+
+use tokio::io::BufReader;
+use tokio::fs::File;
+
+let input = BufReader::new(File::open("events_in.hepmc2").await?);
+let mut in_events = Reader::from(input);
+
+let output = File::create("events_out.hepmc2").await?;
+let mut writer = Writer::try_from(output).await?;
+
+while let Some(event) = in_events.next().await {
+   let event = event?;
+   println!("Current cross section: {}",  event.xs);
+   writer.write(&event).await?
+}
+writer.finish().await?;
+```
+
 License: GPL-3.0-or-later

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sync")]
+
 use std::convert::{AsRef, From};
 use std::default::Default;
 use std::f64::consts::PI;

--- a/hepmc2-macros/Cargo.toml
+++ b/hepmc2-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hepmc2-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+
+[features]
+tokio = []
+sync = []

--- a/hepmc2-macros/src/lib.rs
+++ b/hepmc2-macros/src/lib.rs
@@ -1,0 +1,79 @@
+use proc_macro::{Span, TokenStream};
+use syn::{
+    parse_macro_input, parse_quote, Error, GenericParam, Generics, Item,
+    TypeParamBound,
+};
+
+/// Adds a trait bound to every generic parameter in an impl block or struct
+/// definition
+fn add_trait_bound(
+    mut item: Item,
+    traits: &[TypeParamBound],
+) -> Result<Item, Error> {
+    if let Item::Impl(ref mut impl_item) = item {
+        traits
+            .iter()
+            .for_each(|t| append_generic(&mut impl_item.generics, t));
+        Ok(item)
+    } else if let Item::Struct(ref mut struct_item) = item {
+        traits
+            .iter()
+            .for_each(|t| append_generic(&mut struct_item.generics, t));
+        Ok(item)
+    } else {
+        Err(Error::new(
+            Span::call_site().into(),
+            "macro must be called on impl block or struct definition",
+        ))
+    }
+}
+
+/// Add a bound to every type parameter
+fn append_generic(generics: &mut Generics, picked_trait: &TypeParamBound) {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(picked_trait.clone());
+        }
+    }
+}
+
+fn feature_check() -> Result<(), Error> {
+    if cfg!(all(feature = "sync", feature = "tokio"))
+        || cfg!(not(any(feature = "sync", feature = "tokio")))
+    {
+        Err(Error::new(
+            Span::call_site().into(),
+            "One and only one sync/async feature must be enabled",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Adds the trait bounds required for either sync or async writing
+///
+/// These bounds are applied to all generic parameters in either an impl block or
+/// struct definition.
+///
+/// Traits are chosen according to which features are enabled.
+#[proc_macro_attribute]
+pub fn write_bound(_: TokenStream, item: TokenStream) -> TokenStream {
+    if let Err(e) = feature_check() {
+        return Error::into_compile_error(e).into();
+    }
+    let write_trait = if cfg!(feature = "sync") {
+        vec![parse_quote!(::std::io::Write)]
+    } else if cfg!(feature = "tokio") {
+        vec![
+            parse_quote!(::tokio::io::AsyncWriteExt),
+            parse_quote!(::std::marker::Unpin),
+        ]
+    } else {
+        unreachable!()
+    };
+    let item = add_trait_bound(parse_macro_input!(item as Item), &write_trait);
+    match item {
+        Ok(item) => quote::quote!(#item).into(),
+        Err(e) => Error::into_compile_error(e).into(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
 //!
 //! # Example
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "sync", doc = "```no_run")]
+#![cfg_attr(not(feature = "sync"), doc = "```ignore")]
 //! // Read events from `events_in.hepmc2` and write them to `events_out.hepmc2`
 //! use hepmc2::{Reader, Writer};
 //!
@@ -31,6 +32,61 @@
 //! writer.finish()?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+//! 
+//! ## Async API
+//!
+//! By default this crate enables the `sync` feature which exposes a sync API. You
+//! can however switch to using a `tokio`-backed async API by disabling the `sync`
+//! feature and enabling the `tokio` feature.
+//!
+//! Either run the following in the root of your crate:
+//!
+//! ```sh
+//! cargo add hepmc2 --no-default-features -F tokio
+//! ```
+//!
+//! or make sure a line like the following is present in your `Cargo.toml`:
+//!
+//! ```toml
+//! hepmc2 = { version = "0.6.0", default-features = false, features = ["tokio"] }
+//! ```
+//!
+//! The async API is exactly the same as the sync one but IO operations will return
+//! futures that you will, as usual, need to call `await` on. For examples, generate
+//! the async API documentation in the root of this project:
+//!
+//! ```sh
+//! cargo doc --open --no-default-features -F tokio
+//! ```
+//! 
+//! ### Example
+//! 
+#![cfg_attr(feature = "sync", doc = "```ignore")]
+#![cfg_attr(not(feature = "sync"), doc = "```no_run")]
+//! # async fn try_main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Read events from `events_in.hepmc2` and write them to `events_out.hepmc2`
+//! use hepmc2::{Reader, Writer};
+//!
+//! use tokio::io::BufReader;
+//! use tokio::fs::File;
+//!
+//! let input = BufReader::new(File::open("events_in.hepmc2").await?);
+//! let mut in_events = Reader::from(input);
+//!
+//! let output = File::create("events_out.hepmc2").await?;
+//! let mut writer = Writer::try_from(output).await?;
+//!
+//! while let Some(event) = in_events.next().await {
+//!    let event = event?;
+//!    println!("Current cross section: {}",  event.xs);
+//!    writer.write(&event).await?
+//! }
+//! writer.finish().await?;
+//! # Ok(())
+//! # }
+//! # tokio_test::block_on(async {try_main().await.unwrap()})
+//! ```
+
 pub mod event;
 pub mod reader;
 pub mod writer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! # fn try_main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Read events from `events_in.hepmc2` and write them to `events_out.hepmc2`
 //! use hepmc2::{Reader, Writer};
 //!
@@ -30,8 +29,7 @@
 //!    writer.write(&event)?
 //! }
 //! writer.finish()?;
-//! # Ok(())
-//! # }
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 pub mod event;
 pub mod reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,11 @@ pub use crate::event::Event;
 pub use crate::reader::Reader;
 pub use crate::writer::Writer;
 
+#[cfg(all(feature = "sync", feature = "tokio"))]
+compile_error!("One and only one sync/async feature must be enabled");
+#[cfg(not(any(feature = "sync", feature = "tokio")))]
+compile_error!("One and only one sync/async feature must be enabled");
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,23 +55,29 @@ mod tests {
         assert!(reader.next().is_none());
     }
 
-    #[test]
-    fn tst_read_write() {
+    #[maybe_async::test(
+        feature = "sync",
+        async(
+            all(not(feature = "sync"), feature = "tokio"),
+            tokio::test(flavor = "multi_thread")
+        )
+    )]
+    async fn tst_read_write() {
         use std::io::BufReader;
 
         let mut reader = reader::Reader::from(EVENT_TXT);
         let mut buf = Vec::<u8>::new();
         let event = reader.next().unwrap().unwrap();
         {
-            let mut writer = writer::Writer::try_from(&mut buf).unwrap();
-            writer.write(&event).unwrap();
+            let mut writer = writer::Writer::try_from(&mut buf).await.unwrap();
+            writer.write(&event).await.unwrap();
         }
         let mut reader = reader::Reader::from(BufReader::new(buf.as_slice()));
         let event = reader.next().unwrap().unwrap();
         let mut buf2 = Vec::<u8>::new();
-        let mut writer = writer::Writer::try_from(&mut buf2).unwrap();
-        writer.write(&event).unwrap();
-        writer.finish().unwrap();
+        let mut writer = writer::Writer::try_from(&mut buf2).await.unwrap();
+        writer.write(&event).await.unwrap();
+        writer.finish().await.unwrap();
         use std::str::from_utf8;
         assert_eq!(from_utf8(&buf), from_utf8(&buf2));
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,7 +9,7 @@ use crate::event::*;
 
 use nom::{
     bytes::complete::{take_until, take_while1},
-    character::complete::{char, space1, i32, u64},
+    character::complete::{char, i32, space1, u64},
     combinator::opt,
     number::complete::double,
     sequence::{delimited, preceded, tuple},
@@ -155,7 +155,6 @@ fn parse_event_line(line: &str) -> Result<Event, ParseError> {
     for _ in 0..nrandom_states {
         let (rem, random_state) = ws_i32(rest)?;
         rest = rem;
-        let random_state = random_state;
         random_states.push(random_state);
     }
     let (mut rest, nweights) = ws_u64(rest)?;
@@ -303,10 +302,7 @@ fn parse_pdf_info_line(
         x: [x0, x1],
         scale,
         xf: [xf0, xf1],
-        pdf_id: [
-            pdf_id0.unwrap_or(0),
-            pdf_id1.unwrap_or(0),
-        ],
+        pdf_id: [pdf_id0.unwrap_or(0), pdf_id1.unwrap_or(0)],
     };
     event.pdf_info = pdf_info;
     Ok(())

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -38,15 +38,13 @@ impl<T: Write> Writer<T> {
     /// # Example
     ///
     /// ```rust
-    /// # fn try_main() -> Result<(), Box<dyn std::error::Error>> {
     /// use hepmc2::writer::Writer;
     ///
     /// let mut output = Vec::new();
     /// let mut writer = Writer::new(&mut output)?;
     /// // always call finish at the end
     /// writer.finish()?;
-    /// # Ok(())
-    /// # }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn new(stream: T) -> Result<Self, io::Error> {
         Self::with_header(stream, DEFAULT_HEADER)
@@ -60,15 +58,13 @@ impl<T: Write> Writer<T> {
     /// # Example
     ///
     /// ```rust
-    /// # fn try_main() -> Result<(), Box<dyn std::error::Error>> {
     /// use hepmc2::writer::Writer;
     ///
     /// let mut output = Vec::new();
     /// let mut writer = Writer::with_header(output, "")?;
     /// // always call finish at the end
     /// writer.finish()?;
-    /// # Ok(())
-    /// # }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn with_header<U: Display>(
         stream: T,
@@ -89,15 +85,13 @@ impl<T: Write> Writer<T> {
     /// # Example
     ///
     /// ```rust
-    /// # fn try_main() -> Result<(), Box<dyn std::error::Error>> {
     /// use hepmc2::writer::Writer;
     ///
     /// let mut output = Vec::new();
     /// let mut writer = Writer::new(&mut output)?;
     /// // always call finish at the end
     /// writer.finish()?;
-    /// # Ok(())
-    /// # }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn finish(mut self) -> Result<(), std::io::Error> {
         self.ref_finish()
@@ -108,7 +102,6 @@ impl<T: Write> Writer<T> {
     /// # Example
     ///
     /// ```rust
-    /// # fn try_main() -> Result<(), Box<dyn std::error::Error>> {
     /// use hepmc2::writer::Writer;
     /// use hepmc2::event::Event;
     ///
@@ -118,8 +111,7 @@ impl<T: Write> Writer<T> {
     /// writer.write(&event)?;
     /// // always call finish at the end
     /// writer.finish()?;
-    /// # Ok(())
-    /// # }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn write(&mut self, event: &Event) -> Result<(), io::Error> {
         self.write_event_line(event)?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -60,7 +60,8 @@ impl<T> Writer<T> {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(feature = "sync", doc = "```")]
+    #[cfg_attr(not(feature = "sync"), doc = "```ignore")]
     /// use hepmc2::writer::Writer;
     ///
     /// let mut output = Vec::new();
@@ -68,6 +69,18 @@ impl<T> Writer<T> {
     /// // always call finish at the end
     /// writer.finish()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    #[cfg_attr(feature = "sync", doc = "```ignore")]
+    #[cfg_attr(not(feature = "sync"), doc = "```")]
+    /// # tokio_test::block_on(async {
+    /// use hepmc2::writer::Writer;
+    ///
+    /// let mut output = Vec::new();
+    /// let mut writer = Writer::new(&mut output).await.unwrap();
+    /// // always call finish at the end
+    /// writer.finish().await.unwrap();
+    /// # })
     /// ```
     #[maybe_async::maybe_async]
     pub async fn new(stream: T) -> Result<Self, io::Error> {
@@ -81,7 +94,10 @@ impl<T> Writer<T> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ## Sync
+    ///
+    #[cfg_attr(feature = "sync", doc = "```")]
+    #[cfg_attr(not(feature = "sync"), doc = "```ignore")]
     /// use hepmc2::writer::Writer;
     ///
     /// let mut output = Vec::new();
@@ -89,6 +105,20 @@ impl<T> Writer<T> {
     /// // always call finish at the end
     /// writer.finish()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Async
+    ///
+    #[cfg_attr(feature = "sync", doc = "```ignore")]
+    #[cfg_attr(not(feature = "sync"), doc = "```")]
+    /// # tokio_test::block_on(async {
+    /// use hepmc2::writer::Writer;
+    ///
+    /// let mut output = Vec::new();
+    /// let mut writer = Writer::with_header(output, "").await.unwrap();
+    /// // always call finish at the end
+    /// writer.finish().await.unwrap();
+    /// # })
     /// ```
     #[maybe_async::maybe_async]
     pub async fn with_header<U: Display>(
@@ -109,7 +139,10 @@ impl<T> Writer<T> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ## Sync
+    ///
+    #[cfg_attr(feature = "sync", doc = "```")]
+    #[cfg_attr(not(feature = "sync"), doc = "```ignore")]
     /// use hepmc2::writer::Writer;
     ///
     /// let mut output = Vec::new();
@@ -117,6 +150,20 @@ impl<T> Writer<T> {
     /// // always call finish at the end
     /// writer.finish()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Async
+    ///
+    #[cfg_attr(feature = "sync", doc = "```ignore")]
+    #[cfg_attr(not(feature = "sync"), doc = "```")]
+    /// # tokio_test::block_on(async {
+    /// use hepmc2::writer::Writer;
+    ///
+    /// let mut output = Vec::new();
+    /// let mut writer = Writer::new(&mut output).await.unwrap();
+    /// // always call finish at the end
+    /// writer.finish().await.unwrap();
+    /// # })
     /// ```
     #[maybe_async::maybe_async]
     pub async fn finish(mut self) -> Result<(), std::io::Error> {
@@ -127,7 +174,10 @@ impl<T> Writer<T> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ## Sync
+    ///
+    #[cfg_attr(feature = "sync", doc = "```")]
+    #[cfg_attr(not(feature = "sync"), doc = "```ignore")]
     /// use hepmc2::writer::Writer;
     /// use hepmc2::event::Event;
     ///
@@ -138,6 +188,23 @@ impl<T> Writer<T> {
     /// // always call finish at the end
     /// writer.finish()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// ## Async
+    ///
+    #[cfg_attr(feature = "sync", doc = "```ignore")]
+    #[cfg_attr(not(feature = "sync"), doc = "```")]
+    /// # tokio_test::block_on(async {
+    /// use hepmc2::writer::Writer;
+    /// use hepmc2::event::Event;
+    ///
+    /// let mut output = Vec::new();
+    /// let mut writer = Writer::new(&mut output).await.unwrap();
+    /// let event = Event::default();
+    /// writer.write(&event).await.unwrap();
+    /// // always call finish at the end
+    /// writer.finish().await.unwrap();
+    /// # })
     /// ```
     #[maybe_async::maybe_async]
     pub async fn write(&mut self, event: &Event) -> Result<(), io::Error> {


### PR DESCRIPTION
@a-maier this is a really useful crate - thanks for building it! I've got a contribution here to add an async API to the library.

## Motivation

Asynchronous programming allows programs to continue doing work when waiting on IO calls, rather than being blocked by them. In the case of `hepmc2` it would allow, for example, downstream event generators to continue calculating MEs while waiting for an event to be written to a HepMC file. Given the size of HepMC files that physicists like to generate this could result in sizable performance improvements!

## Changes

The first two commits here are minor pieces of house keeping - the meat of the PR begins after that. Please see the commit messages for some guidance on the changes.

In summary, the async API has exactly the same function signatures as the sync one (`Future`'s not withstanding). I managed to avoid almost all code duplication using a combination of [maybe_async](https://crates.io/crates/maybe-async) and a couple of new macros I added to the library. The latter are placed in a new workspace crate called `hepcm2-macros` (as is standard practice when writing proc macros).

## `maybe-async`

In case you're unfamiliar with it, I can briefly describe the `maybe-async` crate. It provides an attribute macro `maybe_async::maybe_async` that should be applied to blocks of async code. In the case where the feature `maybe-async/is_sync` is enabled,  the macro removes all occurrences of the `async` and  `await` keywords in the block, effectively turning it into sync code. This is how I'm able to use the compiler to generate the sync API from the async one, and so avoiding code duplication.
